### PR TITLE
Upgrade dependencies

### DIFF
--- a/examples/bashreadline/Cargo.toml
+++ b/examples/bashreadline/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-object = { version = "0.27.0", features = ["elf"] }
-libbpf-rs = "0.19"
+object = { version = "0.31.0", features = ["elf"] }
+libbpf-rs = "0.20.1"
 plain = "0.2"
 chrono = "0.4"
-tokio = { version = "1.24", features = ["full"] }
-libbpf-async = {path="../../libbpf-async"}
-rlimit = "0.6"
+tokio = { version = "1.28", features = ["full"] }
+libbpf-async = { path = "../../libbpf-async" }
+rlimit = "0.9.1"
 
 [build-dependencies]
-libbpf-cargo = "0.13"
+libbpf-cargo = "0.20.1"

--- a/examples/bashreadline/src/main.rs
+++ b/examples/bashreadline/src/main.rs
@@ -67,7 +67,7 @@ async fn main() {
         .attach_uprobe(true, -1, BINARY_NAME, offset as usize)
         .unwrap();
 
-    let mut rb = libbpf_async::RingBuffer::new(skel.obj.map_mut(RINGBUF_NAME).unwrap());
+    let mut rb = libbpf_async::RingBuffer::new(skel.obj.map(RINGBUF_NAME).unwrap());
     println!("TIME      PID    COMMAND");
     loop {
         let mut buf = [0; 128];

--- a/examples/profiler/Cargo.toml
+++ b/examples/profiler/Cargo.toml
@@ -6,17 +6,17 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-addr2line = "0.17"
+addr2line = "0.17.0"
 chrono = "0.4"
-clap = { version = "3.1.8", features = ["derive"] }
-libbpf-async = {path="../../libbpf-async"}
-libbpf-rs = "0.19"
-nix = "0.23"
+clap = { version = "4.2.7", features = ["derive"] }
+libbpf-async = { path = "../../libbpf-async" }
+libbpf-rs = "0.20.1"
+nix = "0.26.2"
 num_cpus = "1.0"
-perf-event-open-sys = "1"
+perf-event-open-sys = "4.0.0"
 plain = "0.2"
-rlimit = "0.6"
-tokio = { version = "1.24", features = ["full"] }
+rlimit = "0.9.1"
+tokio = { version = "1.28", features = ["full"] }
 
 [build-dependencies]
-libbpf-cargo = "0.13"
+libbpf-cargo = "0.20.1"

--- a/examples/profiler/src/main.rs
+++ b/examples/profiler/src/main.rs
@@ -116,8 +116,8 @@ fn main() {
     for cpu in 0..num_cpus::get() {
         let mut attrs = sys::bindings::perf_event_attr {
             size: std::mem::size_of::<sys::bindings::perf_event_attr>() as u32,
-            type_: sys::bindings::perf_type_id_PERF_TYPE_SOFTWARE,
-            config: sys::bindings::perf_sw_ids_PERF_COUNT_SW_CPU_CLOCK as u64,
+            type_: sys::bindings::PERF_TYPE_SOFTWARE,
+            config: sys::bindings::PERF_COUNT_SW_CPU_CLOCK as u64,
             __bindgen_anon_1: sys::bindings::perf_event_attr__bindgen_ty_1 { sample_freq: 99 },
             ..Default::default()
         };
@@ -207,7 +207,7 @@ fn main() {
     rt.block_on(async move {
         use tokio::io::AsyncReadExt;
 
-        let mut rb = libbpf_async::RingBuffer::new(skel.obj.map_mut(RINGBUF_NAME).unwrap());
+        let mut rb = libbpf_async::RingBuffer::new(skel.obj.map(RINGBUF_NAME).unwrap());
         loop {
             let mut buf = [0; std::mem::size_of::<Stack>()];
             let n = rb.read(&mut buf).await.unwrap();

--- a/libbpf-async/Cargo.toml
+++ b/libbpf-async/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["bpf", "libbpf", "async"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libbpf-rs = "0.19"
-nix = "0.22"
+libbpf-rs = "0.20.1"
+nix = "0.26.2"
 tokio = { version = "1.24", features = ["full"] }
-page_size = "0.4"
+page_size = "0.5.0"
 futures = "0.3"


### PR DESCRIPTION
Primarily to make libbpf-async compatible with the latest libbpf-rs version, but also other dependencies for overall maintenance.